### PR TITLE
Support file uploads via graphql

### DIFF
--- a/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
+++ b/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapidez\Compadre\Model\CartItem\DataProvider\CustomizableOptionValue;
+
+use Magento\Catalog\Model\Product\Option;
+use Magento\Catalog\Model\Product\Option\Type\Text as TextOptionType;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\GraphQl\Query\Uid;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\Option as SelectedOption;
+use Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\PriceUnitLabel;
+use Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValueInterface;
+
+/**
+ * @inheritdoc
+ */
+class File implements CustomizableOptionValueInterface
+{
+    /**
+     * Option type name
+     */
+    private const OPTION_TYPE = 'custom-option';
+
+    /**
+     * @var PriceUnitLabel
+     */
+    private $priceUnitLabel;
+
+    /** @var Uid */
+    private $uidEncoder;
+
+    /**
+     * @param PriceUnitLabel $priceUnitLabel
+     * @param Uid|null $uidEncoder
+     */
+    public function __construct(
+        PriceUnitLabel $priceUnitLabel,
+        Uid $uidEncoder = null
+    ) {
+        $this->priceUnitLabel = $priceUnitLabel;
+        $this->uidEncoder = $uidEncoder ?: ObjectManager::getInstance()
+            ->get(Uid::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getData(
+        QuoteItem $cartItem,
+        Option $option,
+        SelectedOption $selectedOption
+    ): array {
+        /** @var TextOptionType $optionTypeRenderer */
+        $optionTypeRenderer = $option->groupFactory($option->getType());
+        $optionTypeRenderer->setOption($option);
+        $priceValueUnits = $this->priceUnitLabel->getData($option->getPriceType());
+
+        $selectedOptionValueData = [
+            'id' => $selectedOption->getId(),
+            'customizable_option_value_uid' => $this->uidEncoder->encode(
+                self::OPTION_TYPE . '/' . $option->getOptionId()
+            ),
+            'label' => '',
+            'value' => json_decode($selectedOption->getValue())->title,
+            'price' => [
+                'type' => strtoupper($option->getPriceType()),
+                'units' => $priceValueUnits,
+                'value' => $option->getPrice(),
+            ],
+        ];
+        return [$selectedOptionValueData];
+    }
+}

--- a/src/Model/Plugin/CustomizableOptionDataProviderUploads.php
+++ b/src/Model/Plugin/CustomizableOptionDataProviderUploads.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapidez\Compadre\Model\Plugin;
+
+use Magento\Framework\Api\ImageContent;
+use Magento\Catalog\Model\Webapi\Product\Option\Type\File\Processor as FileProcessor;
+
+class CustomizableOptionDataProviderUploads {
+
+    public function __construct(protected FileProcessor $fileProcessor)
+    {
+    }
+
+    public function afterExecute($subject, $result)
+    {
+        $result['options'] = array_map($this->processFileUpload(...), $result['options']);
+
+        return $result;
+    }
+
+    public function processFileUpload($value) {
+        if (!($decodedValue = @json_decode($value, true))) {
+            return $value;
+        }
+
+        if (array_key_exists('file_info', $decodedValue)) {
+            $decodedValue = $decodedValue['file_info'];
+        }
+
+        if(!array_key_exists('base64_encoded_data', $decodedValue)) {
+            return $value;
+        }
+
+        $response = $this->fileProcessor->processFileContent(new ImageContent($decodedValue));
+        return $response;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Quote\Model\Cart\BuyRequest\CustomizableOptionDataProvider">
+        <plugin name="enable-file-uploads" type="Rapidez\Compadre\Model\Plugin\CustomizableOptionDataProviderUploads" sortOrder="10"/>
+    </type>
+    <type name="Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Composite">
+        <arguments>
+            <argument name="customizableOptionValues" xsi:type="array">
+                <item name="file" xsi:type="string">Rapidez\Compadre\Model\CartItem\DataProvider\CustomizableOptionValue\File</item>
+            </argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
This adds support to upload files in the options by putting a json encoded image with it's type and name in the value field. Example variables for the graphql query is:

```json
{
  "sku": "24-WB04",
  "parent_sku": "24-WB04",
  "cartId": "....",
  "quantity": 1,
  "selected_options": [],
  "entered_options": [
    {
      "uid": "Y3VzdG9tLW9wdGlvbi8y",
      "value": "{\"base64_encoded_data\":\"iVBORw0KGgoAAAANSUhEUgAAA2IAAAFvCAYAAAAornhlAAABWW....==\":\"image/png\",\"name\":\"Screenshot 2023-05-17 at 16.44.46.png\"}"
    }
  ]
}
```