### PR TITLE
Added option to override login-as-customer

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.3
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Allowing you to retrieve the sales rule labels that are applied to a quote item:
     }
 ```
 
+### Login as Customer
+
+When enabled and [rapidez/login-as-customer](https://github.decomv/rapidez/login-as-customer) is installed the admin "Log In As Customer" button will work with Rapidez as well.
+
 ### Other
 And it extends Magento functionality in order to facilitate file upload product options via GraphQL
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Allowing you to retrieve the sales rule labels that are applied to a quote item:
 
 ### Login as Customer
 
-When enabled and [rapidez/login-as-customer](https://github.decomv/rapidez/login-as-customer) is installed the admin "Log In As Customer" button will work with Rapidez as well.
+When enabled and [rapidez/login-as-customer](https://github.com/rapidez/login-as-customer) is installed the admin "Log In As Customer" button will work with Rapidez as well.
 
 ### Other
 And it extends Magento functionality in order to facilitate file upload product options via GraphQL

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
         "magento/module-sales-rule": "*",
         "magento/module-catalog": "*",
         "magento/module-graph-ql": "*",
-        "magento/module-quote-graph-ql": "*"
+        "magento/module-quote-graph-ql": "*",
+        "magento/module-login-as-customer-admin-ui": "*",
+        "magento/module-store": "*",
+        "guzzlehttp/guzzle": "*"
     },
     "require-dev": {
         "bitexpert/phpstan-magento": "^0.11.0",

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,14 @@
         "magento/module-graph-ql": "*",
         "magento/module-quote-graph-ql": "*",
         "magento/module-login-as-customer-admin-ui": "*",
+        "magento/module-login-as-customer-api": "*",
         "magento/module-store": "*",
+        "magento/module-integration": "*",
         "guzzlehttp/guzzle": "*"
     },
     "require-dev": {
-        "bitexpert/phpstan-magento": "^0.11.0",
-        "phpstan/phpstan": "^1.10"
+        "bitexpert/phpstan-magento": "^0.42.0",
+        "phpstan/phpstan": "^2.0"
     },
     "repositories": {
         "magento": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,11 @@ includes:
     - vendor/bitexpert/phpstan-magento/extension.neon
 parameters:
     paths:
-        - .
+        - src
     excludePaths:
         - vendor
         - Test/*
-    level: 5
+    level: 8
+    ignoreErrors:
+        -
+            identifier: missingType.iterableValue

--- a/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
+++ b/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
@@ -40,7 +40,7 @@ class File implements CustomizableOptionValueInterface
         Uid $uidEncoder = null
     ) {
         $this->priceUnitLabel = $priceUnitLabel;
-        $this->uidEncoder = $uidEncoder ?: ObjectManager::getInstance()
+        $this->uidEncoder = $uidEncoder ?: ObjectManager::getInstance() /** @phpstan-ignore-line */
             ->get(Uid::class);
     }
 
@@ -55,7 +55,7 @@ class File implements CustomizableOptionValueInterface
         /** @var TextOptionType $optionTypeRenderer */
         $optionTypeRenderer = $option->groupFactory($option->getType());
         $optionTypeRenderer->setOption($option);
-        $priceValueUnits = $this->priceUnitLabel->getData($option->getPriceType());
+        $priceValueUnits = $this->priceUnitLabel->getData((string) $option->getPriceType());
 
         $selectedOptionValueData = [
             'id' => $selectedOption->getId(),
@@ -65,7 +65,7 @@ class File implements CustomizableOptionValueInterface
             'label' => '',
             'value' => json_decode($selectedOption->getValue())->title,
             'price' => [
-                'type' => strtoupper($option->getPriceType()),
+                'type' => strtoupper((string) $option->getPriceType()),
                 'units' => $priceValueUnits,
                 'value' => $option->getPrice(),
             ],

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -17,7 +17,7 @@ class Config
         protected StoreManagerInterface $storeManager
     ) {}
 
-    public function getConfigValue($field, $storeId = null)
+    public function getConfigValue(string $field, ?int $storeId = null): mixed
     {
         return $this->scopeConfig->getValue(
             $field,
@@ -26,17 +26,17 @@ class Config
         );
     }
 
-    public function getGeneralConfig($code, $storeId = null)
+    public function getGeneralConfig(string $code, ?int $storeId = null): mixed
     {
         return $this->getConfigValue(self::XML_PATH . 'general/' . $code, $storeId);
     }
 
-    public function getGraphQlConfig($code, $storeId = null)
+    public function getGraphQlConfig(string $code, ?int $storeId = null): mixed
     {
         return $this->getConfigValue(self::XML_PATH . 'graphql/' . $code, $storeId);
     }
 
-    public function getLoginAsCustomerConfig($code, $storeId = null)
+    public function getLoginAsCustomerConfig(string $code, ?int $storeId = null): mixed
     {
         return $this->getConfigValue(self::XML_PATH . 'login_as_customer/' . $code, $storeId);
     }
@@ -46,12 +46,12 @@ class Config
         return $this->exposedGraphQlFields ??= explode(',', $this->getGraphQlConfig('expose') ?? '');
     }
 
-    public function isFieldExposed($field): bool
+    public function isFieldExposed(string $field): bool
     {
         return $this->getExposedGraphQlFields() && in_array($field, $this->getExposedGraphQlFields());
     }
 
-    public function getRapidezUrl($storeId = null): string
+    public function getRapidezUrl(?int $storeId = null): string
     {
         if (($rapidezUrl = $this->getGeneralConfig('rapidez_url', $storeId))) {
             return $rapidezUrl;

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -4,6 +4,7 @@ namespace Rapidez\Compadre\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Config
 {
@@ -11,8 +12,10 @@ class Config
 
     private array $exposedGraphQlFields;
 
-    public function __construct(protected ScopeConfigInterface $scopeConfig)
-    {}
+    public function __construct(
+        protected ScopeConfigInterface $scopeConfig,
+        protected StoreManagerInterface $storeManager
+    ) {}
 
     public function getConfigValue($field, $storeId = null)
     {
@@ -23,9 +26,19 @@ class Config
         );
     }
 
+    public function getGeneralConfig($code, $storeId = null)
+    {
+        return $this->getConfigValue(self::XML_PATH . 'general/' . $code, $storeId);
+    }
+
     public function getGraphQlConfig($code, $storeId = null)
     {
         return $this->getConfigValue(self::XML_PATH . 'graphql/' . $code, $storeId);
+    }
+
+    public function getLoginAsCustomerConfig($code, $storeId = null)
+    {
+        return $this->getConfigValue(self::XML_PATH . 'login_as_customer/' . $code, $storeId);
     }
 
     public function getExposedGraphQlFields(): ?array
@@ -36,5 +49,17 @@ class Config
     public function isFieldExposed($field): bool
     {
         return $this->getExposedGraphQlFields() && in_array($field, $this->getExposedGraphQlFields());
+    }
+
+    public function getRapidezUrl($storeId = null): string
+    {
+        if (($rapidezUrl = $this->getGeneralConfig('rapidez_url', $storeId))) {
+            return $rapidezUrl;
+        }
+
+        /** @var \Magento\Store\Model\Store $store */
+        $store = ($storeId ? $this->storeManager->getStore($storeId) : $this->storeManager->getDefaultStoreView());
+
+        return $store->getBaseUrl();
     }
 }

--- a/src/Model/Config/Source/Fields.php
+++ b/src/Model/Config/Source/Fields.php
@@ -14,7 +14,7 @@ class Fields implements ArrayInterface
         ];
     }
 
-    public function toArray()
+    public function toArray() : array
     {
         $array = [];
         foreach ($this->toOptionArray() as $option) {
@@ -24,7 +24,7 @@ class Fields implements ArrayInterface
         return $array;
     }
 
-    public function getProductStockItemFields()
+    public function getProductStockItemFields() : array
     {
         return [
             ['value' => 'in_stock', 'label' => __('stock_item -> in_stock')],

--- a/src/Model/Plugin/CustomizableOptionDataProviderUploads.php
+++ b/src/Model/Plugin/CustomizableOptionDataProviderUploads.php
@@ -13,14 +13,15 @@ class CustomizableOptionDataProviderUploads {
     {
     }
 
-    public function afterExecute($subject, $result)
+    public function afterExecute(\Magento\Quote\Model\Cart\BuyRequest\CustomizableOptionDataProvider $subject, array $result): array
     {
         $result['options'] = array_map($this->processFileUpload(...), $result['options']);
 
         return $result;
     }
 
-    public function processFileUpload($value) {
+    public function processFileUpload(mixed $value) : mixed
+    {
         if (!is_array($value) && !is_array($decodedValue = @json_decode($value, true))) {
             return $value;
         }

--- a/src/Model/Resolver/Quote/Backorder.php
+++ b/src/Model/Resolver/Quote/Backorder.php
@@ -34,6 +34,11 @@ class Backorder implements ResolverInterface
         /** @var Item $cartItem */
         $cartItem = $value['model'];
 
+        if ($cartItem->getSku() === null) 
+        {
+            return null;
+        }
+
         // If used, grab the first configuration of a configurable item and use that
         $configuredItems = $cartItem['qty_options'] ?? [];
         if ($configuredItems) {
@@ -49,8 +54,8 @@ class Backorder implements ResolverInterface
 
         /** @var ProductInterface $product */
         $product = $this->productRepositoryInterface->get($cartItem->getSku());
-        // @phpstan-ignore-next-line
-        $stockItem = $product->getExtensionAttributes()->getStockItem();
+
+        $stockItem = $product->getExtensionAttributes()?->getStockItem();
         if (!$stockItem || $stockItem->getBackorders() != 2) {
             return 0;
         }

--- a/src/Model/Resolver/Quote/Data/SalesRuleLabel.php
+++ b/src/Model/Resolver/Quote/Data/SalesRuleLabel.php
@@ -20,10 +20,14 @@ class SalesRuleLabel implements ResolverInterface
 
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
-        /** @var Item */
-        $cartItem = $value['model'];
+        /** @var ?Item $cartItem */
+        $cartItem = $value['model'] ?? null;
 
         $labels = [];
+
+        if (!$cartItem) {
+            return $labels;
+        }
 
         foreach (explode(',', (string) $cartItem->getAppliedRuleIds()) as $key=>$ruleId) {
             try {
@@ -37,7 +41,7 @@ class SalesRuleLabel implements ResolverInterface
             $store = $context->getExtensionAttributes()->getStore();
             $storeId = $store->getId();
 
-            foreach($rule->getStoreLabels() as $storeLabel) {
+            foreach($rule->getStoreLabels() ?? [] as $storeLabel) {
                 if ((int) $storeLabel->getStoreId() === (int) $storeId) {
                     $storeLabel = $storeLabel->getStoreLabel();
                     break;

--- a/src/Plugin/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/LoginPlugin.php
+++ b/src/Plugin/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/LoginPlugin.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rapidez\Compadre\Plugin\LoginAsCustomerAdminUi\Controller\Adminhtml\Login;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientFactory;
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\Auth\Session;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\Config\Share;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json as JsonResult;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Url;
+use Magento\Integration\Model\Oauth\TokenFactory;
+use Magento\LoginAsCustomerAdminUi\Controller\Adminhtml\Login\Login;
+use Magento\LoginAsCustomerApi\Api\ConfigInterface;
+use Magento\LoginAsCustomerApi\Api\Data\AuthenticationDataInterface;
+use Magento\LoginAsCustomerApi\Api\Data\AuthenticationDataInterfaceFactory;
+use Magento\LoginAsCustomerApi\Api\DeleteAuthenticationDataForUserInterface;
+use Magento\LoginAsCustomerApi\Api\IsLoginAsCustomerEnabledForCustomerInterface;
+use Magento\LoginAsCustomerApi\Api\SaveAuthenticationDataInterface;
+use Magento\LoginAsCustomerApi\Api\SetLoggedAsCustomerCustomerIdInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Rapidez\Compadre\Model\Config;
+
+class LoginPlugin
+{
+    /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_LoginAsCustomer::login';
+
+    /**
+     * @var RequestInterface
+     */
+    private $_request;
+
+    /**
+     * @var Share
+     */
+    private $share;
+
+    /**
+     * @var SetLoggedAsCustomerCustomerIdInterface
+     */
+    private $setLoggedAsCustomerCustomerId;
+
+    /**
+     * @var IsLoginAsCustomerEnabledForCustomerInterface
+     */
+    private $isLoginAsCustomerEnabled;
+
+    /**
+     * @param Context $context
+     * @param Session $authSession
+     * @param StoreManagerInterface $storeManager
+     * @param CustomerRepositoryInterface $customerRepository
+     * @param ConfigInterface $config
+     * @param AuthenticationDataInterfaceFactory $authenticationDataFactory
+     * @param SaveAuthenticationDataInterface $saveAuthenticationData
+     * @param DeleteAuthenticationDataForUserInterface $deleteAuthenticationDataForUser
+     * @param Url $url
+     * @param Share|null $share
+     * @param SetLoggedAsCustomerCustomerIdInterface|null $setLoggedAsCustomerCustomerId
+     * @param IsLoginAsCustomerEnabledForCustomerInterface|null $isLoginAsCustomerEnabled
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        protected Context $context,
+        protected Session $authSession,
+        protected StoreManagerInterface $storeManager,
+        protected CustomerRepositoryInterface $customerRepository,
+        protected ConfigInterface $config,
+        protected AuthenticationDataInterfaceFactory $authenticationDataFactory,
+        protected SaveAuthenticationDataInterface $saveAuthenticationData,
+        protected DeleteAuthenticationDataForUserInterface $deleteAuthenticationDataForUser,
+        protected resultFactory $resultFactory,
+        protected Url $url,
+        protected Config $rapidezConfig,
+        protected TokenFactory $tokenFactory,
+        protected ClientFactory $clientFactory,
+        ?Share $share = null,
+        ?SetLoggedAsCustomerCustomerIdInterface $setLoggedAsCustomerCustomerId = null,
+        ?IsLoginAsCustomerEnabledForCustomerInterface $isLoginAsCustomerEnabled = null,
+    ) {
+        $this->_request = $context->getRequest();
+        $this->share = $share ?? ObjectManager::getInstance()->get(Share::class);
+        $this->setLoggedAsCustomerCustomerId = $setLoggedAsCustomerCustomerId
+            ?? ObjectManager::getInstance()->get(SetLoggedAsCustomerCustomerIdInterface::class);
+        $this->isLoginAsCustomerEnabled = $isLoginAsCustomerEnabled
+            ?? ObjectManager::getInstance()->get(IsLoginAsCustomerEnabledForCustomerInterface::class);
+    }
+
+    /**
+     * Login as customer
+     *
+     * @return ResultInterface
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function aroundExecute(Login $subject, callable $proceed): ResultInterface
+    {
+        $messages = [];
+
+        $customerId = (int)$this->_request->getParam('customer_id');
+        if (!$customerId) {
+            $customerId = (int)$this->_request->getParam('entity_id');
+        }
+
+        $isLoginAsCustomerEnabled = $this->isLoginAsCustomerEnabled->execute($customerId);
+        if (!$isLoginAsCustomerEnabled->isEnabled()) {
+            foreach ($isLoginAsCustomerEnabled->getMessages() as $message) {
+                $messages[] = __($message);
+            }
+
+            return $this->prepareJsonResult($messages);
+        }
+
+        try {
+            $customer = $this->customerRepository->getById($customerId);
+        } catch (NoSuchEntityException $e) {
+            $messages[] = __('Customer with this ID no longer exists.');
+            return $this->prepareJsonResult($messages);
+        }
+
+        if ($this->config->isStoreManualChoiceEnabled()) {
+            $storeId = (int)$this->_request->getParam('store_id');
+            if (empty($storeId)) {
+                $messages[] = __('Please select a Store to login in.');
+                return $this->prepareJsonResult($messages);
+            }
+        } elseif ($this->share->isGlobalScope()) {
+            $storeId = (int)$this->storeManager->getDefaultStoreView()->getId();
+        } else {
+            $storeId = (int)$customer->getStoreId();
+        }
+
+        if (!$this->rapidezConfig->getLoginAsCustomerConfig('override', $storeId)) {
+            return $proceed();
+        }
+
+        $adminUser = $this->authSession->getUser();
+        $userId = (int)$adminUser->getId();
+
+        /** @var AuthenticationDataInterface $authenticationData */
+        $authenticationData = $this->authenticationDataFactory->create(
+            [
+                'customerId' => $customerId,
+                'adminId' => $userId,
+                'extensionAttributes' => null,
+            ]
+        );
+
+        $this->deleteAuthenticationDataForUser->execute($userId);
+        $this->saveAuthenticationData->execute($authenticationData);
+        $this->setLoggedAsCustomerCustomerId->execute($customerId);
+
+        $redirectUrl = $this->getLoginProceedRedirectUrl($customerId, $storeId);
+
+        if (!$redirectUrl) {
+            return $proceed();
+        }
+
+        return $this->prepareJsonResult($messages, $redirectUrl);
+    }
+
+    /**
+     * Get login proceed redirect url
+     *
+     * @param string $secret
+     * @param int $storeId
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    private function getLoginProceedRedirectUrl(int $customerId, int $storeId): ?string
+    {
+        $token = $this->tokenFactory->create()->createCustomerToken($customerId)->getToken();
+
+        /** @var Client $client */
+        $client = $this->clientFactory->create(['config' => [
+            'base_uri' => $this->rapidezConfig->getRapidezUrl($storeId)
+        ]]);
+
+        $response = $client->request(
+            'POST',
+            '/api/get-login-as-customer-url',
+            [
+                'json' => [
+                    'token' => $token,
+                ],
+                'headers' => [
+                    'Accept' => 'application/json',
+                ]
+            ]
+        );
+
+        /** @var ?string $url */
+        $url = json_decode((string)$response->getBody(), false)?->url;
+
+        return $url;
+    }
+
+    /**
+     * Prepare JSON result
+     *
+     * @param array $messages
+     * @param string|null $redirectUrl
+     * @return JsonResult
+     */
+    private function prepareJsonResult(array $messages, ?string $redirectUrl = null)
+    {
+        /** @var JsonResult $jsonResult */
+        $jsonResult = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+
+        $jsonResult->setData([
+            'redirectUrl' => $redirectUrl,
+            'messages' => $messages,
+        ]);
+
+        return $jsonResult;
+    }
+}

--- a/src/Plugin/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/LoginPlugin.php
+++ b/src/Plugin/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/LoginPlugin.php
@@ -59,21 +59,6 @@ class LoginPlugin
      */
     private $isLoginAsCustomerEnabled;
 
-    /**
-     * @param Context $context
-     * @param Session $authSession
-     * @param StoreManagerInterface $storeManager
-     * @param CustomerRepositoryInterface $customerRepository
-     * @param ConfigInterface $config
-     * @param AuthenticationDataInterfaceFactory $authenticationDataFactory
-     * @param SaveAuthenticationDataInterface $saveAuthenticationData
-     * @param DeleteAuthenticationDataForUserInterface $deleteAuthenticationDataForUser
-     * @param Url $url
-     * @param Share|null $share
-     * @param SetLoggedAsCustomerCustomerIdInterface|null $setLoggedAsCustomerCustomerId
-     * @param IsLoginAsCustomerEnabledForCustomerInterface|null $isLoginAsCustomerEnabled
-     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
-     */
     public function __construct(
         protected Context $context,
         protected Session $authSession,
@@ -93,10 +78,10 @@ class LoginPlugin
         ?IsLoginAsCustomerEnabledForCustomerInterface $isLoginAsCustomerEnabled = null,
     ) {
         $this->_request = $context->getRequest();
-        $this->share = $share ?? ObjectManager::getInstance()->get(Share::class);
-        $this->setLoggedAsCustomerCustomerId = $setLoggedAsCustomerCustomerId
+        $this->share = $share ?? ObjectManager::getInstance()->get(Share::class); /** @phpstan-ignore-line */
+        $this->setLoggedAsCustomerCustomerId = $setLoggedAsCustomerCustomerId /** @phpstan-ignore-line */
             ?? ObjectManager::getInstance()->get(SetLoggedAsCustomerCustomerIdInterface::class);
-        $this->isLoginAsCustomerEnabled = $isLoginAsCustomerEnabled
+        $this->isLoginAsCustomerEnabled = $isLoginAsCustomerEnabled /** @phpstan-ignore-line */
             ?? ObjectManager::getInstance()->get(IsLoginAsCustomerEnabledForCustomerInterface::class);
     }
 
@@ -139,7 +124,7 @@ class LoginPlugin
                 return $this->prepareJsonResult($messages);
             }
         } elseif ($this->share->isGlobalScope()) {
-            $storeId = (int)$this->storeManager->getDefaultStoreView()->getId();
+            $storeId = (int)$this->storeManager->getDefaultStoreView()?->getId();
         } else {
             $storeId = (int)$customer->getStoreId();
         }
@@ -176,7 +161,7 @@ class LoginPlugin
     /**
      * Get login proceed redirect url
      *
-     * @param string $secret
+     * @param int $customerId
      * @param int $storeId
      * @return string
      * @throws NoSuchEntityException

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -8,12 +8,27 @@
             <label>Config</label>
             <tab>rapidez</tab>
             <resource>Rapidez_Compadre::config_Rapidez_Compadre</resource>
+            <group id="general" sortOrder="5" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+                <label>General</label>
+                <field id="rapidez_url" type="text" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+                    <label>Rapidez Url</label>
+                    <comment>The base Rapidez url of your site e.g https://example.com, if left empty the base url of the store view will be used.</comment>
+                </field>
+            </group>
             <group id="graphql" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
                 <label>Graphql</label>
                 <field id="expose" type="multiselect" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
                     <label>Expose</label>
                     <comment>The fields will still be visible, and you can try to request them. However they will always be null</comment>
                     <source_model>Rapidez\Compadre\Model\Config\Source\Fields</source_model>
+                </field>
+            </group>
+            <group id="login_as_customer" sortOrder="15" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+                <label>Login As Customer</label>
+                <field id="override" canRestore="1" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Override login as customer to Rapidez</label>
+                    <comment>Should we override the admin "Login As Customer" button to redirect to the Rapidez shop? (make sure rapidez/login-as-customer is installed)</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
         </section>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -11,4 +11,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\LoginAsCustomerAdminUi\Controller\Adminhtml\Login\Login">
+        <plugin name="override-login-as-customer" type="Rapidez\Compadre\Plugin\LoginAsCustomerAdminUi\Controller\Adminhtml\Login\LoginPlugin" sortOrder="10"/>
+    </type>
 </config>


### PR DESCRIPTION
This adds the pieces allowing Admin users to login as customer using the Magento "Login as customer" button

It builds on the functionality added in: https://github.com/rapidez/login-as-customer/pull/16
Communicating the customer token to Rapidez in a similar way as has been done with the Standalone Checkout