### PR TITLE
Added collapsible filters support

### DIFF
--- a/src/Model/Config/Source/Attributes.php
+++ b/src/Model/Config/Source/Attributes.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rapidez\Compadre\Model\Config\Source;
+
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
+use Magento\Framework\Option\ArrayInterface;
+
+class Attributes implements ArrayInterface
+{
+    public function __construct(
+        protected CollectionFactory $attributeCollectionFactory
+    ) {}
+
+    public function toOptionArray(): array
+    {
+        $options = [];
+        $collection = $this->attributeCollectionFactory->create();
+        $collection->addVisibleFilter();
+
+        foreach ($collection as $attribute) {
+            $options[] = [
+                'value' => $attribute->getAttributeCode(),
+                'label' => $attribute->getFrontendLabel() ?: $attribute->getAttributeCode(),
+            ];
+        }
+
+        usort($options, fn($a, $b) => strcmp((string) $a['label'], (string) $b['label']));
+
+        return $options;
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -31,6 +31,15 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
+            <group id="catalog" sortOrder="20" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+                <label>Catalog</label>
+                <field id="collapsed_attributes" translate="label comment" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Collapsed Attributes</label>
+                    <comment>Select the attributes for which the filters should be collapsed by default.</comment>
+                    <source_model>Rapidez\Compadre\Model\Config\Source\Attributes</source_model>
+                    <can_be_empty>1</can_be_empty>
+                </field>
+            </group>
         </section>
     </system>
 </config>


### PR DESCRIPTION
This PR adds the configuration for collapsible filter support.
Filters selected will be collapsed by default.

Implemented by: https://github.com/rapidez/core/pull/1335
Ref: FW-2421